### PR TITLE
Fix failing integration tests by excluding cloud dir

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -66,5 +66,6 @@
     "skipLibCheck": true /* Skip type checking of declaration files. */,
     // "forceConsistentCasingInFileNames": true,  /* Disallow inconsistently-cased references to the same file. */
     "resolveJsonModule": true
-  }
+  },
+  "exclude": ["cloud"]
 }


### PR DESCRIPTION
The tsc compiler fails when the cloud directory is present. Ignore cdk to avoid build failures with rest of the project source code.